### PR TITLE
English locale support

### DIFF
--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -1,0 +1,12 @@
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_USER=docker
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_DATABASE=${DB_NAME}
+    volumes:
+      - db_data:/var/lib/postgres/data
+      - files_private_data:/var/www/files_private
+    ports:
+      - "5432:5432"
+    container_name: ${DOCKER_NAME}_db

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -5,7 +5,7 @@
       - POSTGRES_PASSWORD=docker
       - POSTGRES_DATABASE=${DB_NAME}
     volumes:
-      - db_data:/var/lib/postgres/data
+      - /var/lib/postgres/data:/var/lib/postgres/data
       - files_private_data:/var/www/files_private
     ports:
       - "5432:5432"

--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -3,6 +3,25 @@ FROM $BASE_IMAGE
 
 COPY php.ini /usr/local/etc/php/php.ini
 
+# Proper locale needed to use Postgres
+RUN echo "en_US" > /usr/local/etc/locale.md
+
+# Install language pack
+RUN apk --no-cache add ca-certificates wget && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-bin-2.31-r0.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-i18n-2.31-r0.apk && \
+    apk add glibc-bin-2.31-r0.apk glibc-i18n-2.31-r0.apk glibc-2.31-r0.apk
+
+# Iterate through all locale and install it
+# Note that locale -a is not available in alpine linux, use `/usr/glibc-compat/bin/locale -a` instead
+RUN cat /usr/local/etc/locale.md | xargs -i /usr/glibc-compat/bin/localedef -i {} -f UTF-8 {}.UTF-8
+
+# Set the lang, you can also specify it as as environment variable through docker-compose.yml
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
 ## START CI
 
 WORKDIR /var/www


### PR DESCRIPTION
When trying to use Postgres for the database, Drupal throws an error when running the installation via Drush that an appropriate encoding is not available. I have updated the Dockerfile to add support for en_US.utf-8. Also added an example file showing how to set up Postgres.