### PR TITLE
Fix PHP Redis install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,13 @@ RUN apk add --update --no-cache icu \
     \
     apk del .build-deps
 
+# Redis
+RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/5.3.2.tar.gz \
+    && tar xfz /tmp/redis.tar.gz \
+    && rm -r /tmp/redis.tar.gz \
+    && mv phpredis-5.3.2 /usr/src/php/ext/redis \
+    && docker-php-ext-install redis
+
 # Composer recommended settings
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_VERSION 2.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apk add --update --no-cache icu \
 RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/5.3.2.tar.gz \
     && tar xfz /tmp/redis.tar.gz \
     && rm -r /tmp/redis.tar.gz \
+    && mkdir --parents /usr/src/php/ext \
     && mv phpredis-5.3.2 /usr/src/php/ext/redis \
     && docker-php-ext-install redis
 

--- a/conf/drupal/default.settings.php
+++ b/conf/drupal/default.settings.php
@@ -773,3 +773,4 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 #   include $app_root . '/' . $site_path . '/settings.local.php';
 # }
+$settings["config_sync_directory"] = 'sites/default/files/config/sync';

--- a/conf/drupal/settings.php
+++ b/conf/drupal/settings.php
@@ -782,3 +782,5 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 #   include $app_root . '/' . $site_path . '/settings.local.php';
 # }
+
+$settings["config_sync_directory"] = 'sites/default/files/config/sync';


### PR DESCRIPTION
Creates the missing parent directories that are breaking the PHP Redis install step of the Docker image build.

This is currently breaking CI that relies on the docker-scaffold project:
https://github.com/drupalwxt/site-wxt/runs/1443350406?check_suite_focus=true#step:5:823

Happy to tweak this PR if you want to make the change in a different way!