### PR TITLE
Emergency fix for bad package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --update add --no-cache bash=5.0.17-r0 \
                                 git \
                                 gzip=1.10-r0 \
                                 mysql-client \
-                                patch=2.7.6-r6 \
+                                patch=2.7.6-r7 \
                                 postgresql-client \
                                 ssmtp=2.64-r14 \
                                 zlib-dev=1.2.11-r3


### PR DESCRIPTION
issue started June 22 2021

Linked to issue: https://github.com/drupalwxt/docker-scaffold/issues/6