### PR TITLE
Update Dockerfile patch to copy config/ directory into image

### DIFF
--- a/patches/custom-mounts.patch
+++ b/patches/custom-mounts.patch
@@ -1,7 +1,7 @@
 diff --git a/Dockerfile b/Dockerfile
 index 411d65c..e4a4d1c 100644
---- a/Dockerfile
-+++ b/Dockerfile
+--- a/docker/Dockerfile
++++ b/docker/Dockerfile
 @@ -92,6 +92,11 @@ RUN rm -rf /var/www/*
  COPY scripts/ScriptHandler.php /var/www/scripts/ScriptHandler.php
  COPY composer.json /var/www/composer.json

--- a/patches/custom-mounts.patch
+++ b/patches/custom-mounts.patch
@@ -1,25 +1,16 @@
-From ac407afbe7952a6d6f391988f6f9c4bf262aff67 Mon Sep 17 00:00:00 2001
-From: William Hearn <sylus1984@gmail.com>
-Date: Tue, 8 Dec 2020 15:37:44 -0500
-Subject: [PATCH] feat(docker): Add custom paths
-
----
- Dockerfile | 3 +++
- 1 file changed, 3 insertions(+)
-
 diff --git a/Dockerfile b/Dockerfile
-index 3cc06c7..1a7595e 100644
---- a/docker/Dockerfile
-+++ b/docker/Dockerfile
-@@ -76,6 +76,9 @@ RUN rm -rf /var/www/*
+index 411d65c..e4a4d1c 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -92,6 +92,11 @@ RUN rm -rf /var/www/*
  COPY scripts/ScriptHandler.php /var/www/scripts/ScriptHandler.php
  COPY composer.json /var/www/composer.json
  COPY composer.lock /var/www/composer.lock
-+# Copy and custom modules and / or themes
++# Copy custom modules and themes
 +COPY html/modules/custom/ /var/www/html/modules/custom/
 +COPY html/themes/custom/ /var/www/html/themes/custom/
++# Copy config directory
++COPY config/ /var/www/config/
  WORKDIR /var/www
  RUN apk --update --no-cache add git openssh-client; \
      mkdir -p /root/.ssh; echo $SSH_PRIVATE_KEY | base64 -d > /root/.ssh/id_rsa; \
---
-2.21.0 (Apple Git-122)


### PR DESCRIPTION
Update Dockerfile patch to copy config/ directory into image.

Might be good to add a /config directory to drupalwxt/site-wxt repo with a README file just to have a /config directory on initial install since I believe COPY will fail if directory doesn't exist.