### PR TITLE
Update nginx config to set pm to dynamic and max_children to 50

### DIFF
--- a/images/monolith/conf/nginx.conf
+++ b/images/monolith/conf/nginx.conf
@@ -5,6 +5,12 @@ user nginx;
 worker_processes auto;
 worker_rlimit_nofile 100000;
 
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+
 events {
   multi_accept on;
   use epoll;


### PR DESCRIPTION
Increase max_children to 50.

16GB RAM, 53MB average pool size. 50 is still a conservative number based on calculations.