### PR TITLE
Conditionally copy auth.json file for private repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,3 +115,6 @@ RUN ln -s /var/www/vendor/drush/drush/drush /usr/local/bin/drush
 
 # Reset Cache
 RUN php -r 'opcache_reset();'
+
+# Remove auth.json
+RUN rm -f /var/www/auth.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,7 @@ RUN rm -f /var/www/composer.lock; \
     rm -rf /root/.composer
 RUN rm -rf /var/www/*
 COPY scripts/ScriptHandler.php /var/www/scripts/ScriptHandler.php
-COPY composer.json /var/www/composer.json
-COPY composer.lock /var/www/composer.lock
+COPY composer.json composer.lock auth.json* /var/www/
 WORKDIR /var/www
 RUN apk --update --no-cache add git openssh-client; \
     mkdir -p /root/.ssh; echo $SSH_PRIVATE_KEY | base64 -d > /root/.ssh/id_rsa; \


### PR DESCRIPTION
I need to support private GitHub repos in my builds, which requires an auth.json file at the root of the repo. Adding a conditional copy for auth.json. Tested with private GitHub repo and works as expected. Also tested without an auth.json file in repo and doesn't fail on COPY command. Could also be used for private packagist and GitLab repos.