### PR TITLE
Fix drupal_install to work with psql, add drupal_import_config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,23 @@ drupal_import:
 		docker-compose exec cli bash /var/www/docker/bin/cli drupal-import wxt "${DATABASE_BACKUP}"; \
 	fi
 
+# Import configuration to existing Drupal install
+#
+# uuid = Site UUID (drush cget system.site uuid)
+# en_uuid = English language UUID (drush cget language.entity.en uuid)
+# shortcut_uuid = Shortcut UUID (drush cget shortcut.set.default uuid)
+# queue_uuid = Entityqueue UUID (drush cget entityqueue.entity_queue.front_page uuid)
+#
+drupal_import_config:
+	./docker/bin/drush cset system.site uuid $(uuid) --yes
+	./docker/bin/drush cset language.entity.en uuid $(en_uuid) --yes
+	./docker/bin/drush cset shortcut.set.default uuid $(shortcut_uuid) --yes
+	./docker/bin/drush cset entityqueue.entity_queue.front_page uuid $(queue_uuid) --yes
+	./docker/bin/drush cr
+	./docker/bin/drush cim -y
+	./docker/bin/drush cr
+	./docker/bin/drush php-eval 'node_access_rebuild();'
+
 drupal_migrate:
 	if [ "$(CI)" ]; then \
 		docker-compose exec -T cli bash /var/www/docker/bin/cli drupal-migrate; \
@@ -183,6 +200,7 @@ update: base
 	docker_build \
 	drupal_cs \
 	drupal_export \
+	drupal_import_config \
 	drupal_install \
 	drupal_import \
 	drupal_migrate \

--- a/bin/cli
+++ b/bin/cli
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../.env
 
 # Docroot.
 cd /var/www/html/;
@@ -54,7 +55,7 @@ drupal_install() {
   set -e
   time drush si "${OPTION}" \
     --sites-subdir=default \
-    --db-url=mysql://root:root@db:3306/"${OPTION}" \
+    --db-url=pgsql://root:root@"$DOCKER_NAME"_db:5432/"${OPTION}" \
     --account-name=admin \
     --account-pass=Drupal@2019 \
     --site-mail=admin@example.com \
@@ -63,6 +64,9 @@ drupal_install() {
     install_configure_form.update_status_module='array(FALSE,FALSE)' \
     --yes
   set +e
+
+  echo "\$settings['config_sync_directory'] = '../config/sync';" >> sites/default/settings.php
+  drush config-set wxt_library.settings wxt.theme theme-gcweb --yes
 }
 
 # drupal_export

--- a/bin/cli
+++ b/bin/cli
@@ -1,5 +1,4 @@
 #!/bin/bash
-source ../.env
 
 # Docroot.
 cd /var/www/html/;
@@ -55,7 +54,7 @@ drupal_install() {
   set -e
   time drush si "${OPTION}" \
     --sites-subdir=default \
-    --db-url=pgsql://root:root@"$DOCKER_NAME"_db:5432/"${OPTION}" \
+    --db-url=pgsql://root:root@db:5432/"${OPTION}" \
     --account-name=admin \
     --account-pass=Drupal@2019 \
     --site-mail=admin@example.com \
@@ -66,7 +65,6 @@ drupal_install() {
   set +e
 
   echo "\$settings['config_sync_directory'] = '../config/sync';" >> sites/default/settings.php
-  drush config-set wxt_library.settings wxt.theme theme-gcweb --yes
 }
 
 # drupal_export


### PR DESCRIPTION
This PR fixes an issue with the drupal_install cli command. In the 9.4.x-postgres branch it needs to install Drupal using postgres (not mysql). Also included the .env file to allow passing of $DOCKER_NAME to the drush si command.

Added a new drupal_import_config Makefile command that sets the required UUIDs to install a site using config files (from config sync).