### PR TITLE
Fix persistent DB issue

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -61,7 +61,7 @@ services:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
     volumes:
-      - db_data:/var/lib/postgresql
+      - db_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     container_name: ${DOCKER_NAME}_db

--- a/docker-compose-mutagen.yml
+++ b/docker-compose-mutagen.yml
@@ -55,7 +55,7 @@ services:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
     volumes:
-      - db_data:/var/lib/postgresql
+      - db_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     container_name: ${DOCKER_NAME}_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
     volumes:
-      - db_data:/var/lib/postgresql
+      - db_data:/var/lib/postgresql/data
       - files_private_data:/var/www/files_private
     ports:
       - "5432:5432"


### PR DESCRIPTION
With the 9.4.x-postgres branch, when I run `make docker_stop` and then `make docker_start`, my previously installed site is no longer available and I'm presented with the Drupal install screen. This is due to an incorrect volume with the db container.