### PR TITLE
Add PGDATA variable

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -60,6 +60,7 @@ services:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:

--- a/docker-compose-mutagen.yml
+++ b/docker-compose-mutagen.yml
@@ -54,6 +54,7 @@ services:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=root
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - db_data:/var/lib/postgresql/data
       - files_private_data:/var/www/files_private


### PR DESCRIPTION
With the changes in previous PR to make the database persistent, I ran into an issue when I tried to spin up my containers. My DB container would spin up but then exit directly after, giving an error about existing data. I found [this thread](https://github.com/docker-library/postgres/issues/263#issuecomment-280504406) that suggests adding the PGDATA variable to a sub-directory to prevent this issue. After adding this to docker-compose I was able to spin up my DB container even if it had an existing database installed.