### PR TITLE
Configure nginx and varnish for appsvc image

### DIFF
--- a/images/appsvc/Dockerfile
+++ b/images/appsvc/Dockerfile
@@ -12,6 +12,8 @@ COPY conf/supervisord.ini /etc/supervisor.d/supervisord.ini
 RUN apk add --no-cache nginx
 RUN mkdir -p /etc/nginx
 
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+
 # Configure cron
 COPY tasks/ /etc/periodic/
 RUN chmod -R +x /etc/periodic/
@@ -19,6 +21,9 @@ RUN chmod -R +x /etc/periodic/
 # Configure varnish
 RUN apk add --no-cache varnish
 RUN mkdir -p /etc/varnish
+
+COPY conf/default.vcl /etc/varnish/default.vcl
+COPY conf/splash.html /etc/varnish/splash.html
 
 # ------------------------
 # SSH Server support

--- a/images/appsvc/conf/default.vcl
+++ b/images/appsvc/conf/default.vcl
@@ -1,0 +1,202 @@
+vcl 4.0;
+
+import std;
+import directors;
+
+backend nginx {
+  .host = "localhost";
+  .host_header = "nginx";
+  .port = "8080";
+}
+
+sub vcl_init {
+  new backends = directors.round_robin();
+  backends.add_backend(nginx);
+}
+
+sub vcl_recv {
+  set req.http.X-Forwarded-Host = req.http.Host;
+  if (!req.http.X-Forwarded-Proto) {
+    set req.http.X-Forwarded-Proto = "http";
+  }
+
+  # Answer healthcheck
+  if (req.url == "/_healthcheck" || req.url == "/healthcheck.txt") {
+    return (synth(700, "HEALTHCHECK"));
+  }
+
+  # Answer splashpage
+  if (req.url == "/") {
+    return (synth(701, "SPLASH"));
+  }
+
+  set req.backend_hint = backends.backend();
+
+  # Always cache certain file types
+  # Remove cookies that Drupal doesn't care about
+  if (req.url ~ "(?i)\.(asc|dat|tgz|png|gif|jpeg|jpg|ico|swf|css|js)(\?.*)?$") {
+    unset req.http.Cookie;
+  } else if (req.http.Cookie) {
+    set req.http.Cookie = ";" + req.http.Cookie;
+    set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
+    set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+    set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
+    if (req.http.Cookie == "") {
+        unset req.http.Cookie;
+    } else {
+        return (pass);
+    }
+  }
+  # If POST, PUT or DELETE, then don't cache
+  if (req.method == "POST" || req.method == "PUT" || req.method == "DELETE") {
+    return (pass);
+  }
+  # Happens before we check if we have this in cache already.
+  #
+  # Typically you clean up the request here, removing cookies you don't need,
+  # rewriting the request, etc.
+  return (hash);
+  #return (pass);
+}
+
+sub vcl_backend_fetch {
+  # NEW
+  set bereq.http.Host = "nginx";
+
+  # Don't add 127.0.0.1 to X-Forwarded-For
+  set bereq.http.X-Forwarded-For = regsub(bereq.http.X-Forwarded-For, "(, )?127\.0\.0\.1$", "");
+}
+
+sub vcl_backend_response {
+  if (beresp.http.Location && beresp.http.Location !~ "^https://api.twitter.com/") {
+    set beresp.http.Location = regsub(
+      beresp.http.Location,
+      "^https?://[^/]+/",
+      bereq.http.X-Forwarded-Proto + "://" + bereq.http.X-Forwarded-Host + "/"
+    );
+  }
+  # Only cache select response codes
+  if (beresp.status == 200 || beresp.status == 203 || beresp.status == 204 || beresp.status == 206 || beresp.status == 300 || beresp.status == 301 || beresp.status == 404 || beresp.status == 405 || beresp.status == 410 || beresp.status == 414 || beresp.status == 501) {
+    # Cache for 5 minutes
+    set beresp.ttl = 5m;
+    set beresp.grace = 12h;
+    set beresp.keep = 24h;
+  } else {
+    set beresp.ttl = 0s;
+  }
+}
+
+sub vcl_deliver {
+  # Remove identifying information
+  unset resp.http.Server;
+  unset resp.http.X-Powered-By;
+  unset resp.http.X-Varnish;
+  unset resp.http.Via;
+
+  # Comment these for easier Drupal cache tag debugging in development.
+  unset resp.http.Cache-Tags;
+  unset resp.http.X-Drupal-Cache-Contexts;
+
+  # Add Content-Security-Policy
+  # set resp.http.Content-Security-Policy = "default-src 'self' *.example.ca *.example.ca; style-src 'self' 'unsafe-inline' *.example.ca https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.example.ca  *.adobedtm.com use.fontawesome.com blob:; connect-src 'self' *.example.ca *.omtrdc.net *.demdex.net *.everesttech.net; img-src 'self' *.example.ca *.omtrdc.net *.demdex.net *.everesttech.net data:; font-src 'self' *.example.ca https://fonts.gstatic.com";
+
+  # Add CORS Headers
+  # if (req.http.Origin ~ "(?i)\.example\.ca$") {
+  #   if (req.url ~ "\.(ttd|woff|woff2)(\?.*)?$") {
+  #     set resp.http.Access-Control-Allow-Origin = "*";
+  #     set resp.http.Access-Control-Allow-Methods = "GET";
+  #   }
+  # }
+
+  # Add X-Frame-Options
+  # if (req.url ~ "^/(en/|fr/)?media/") {
+  #   set resp.http.X-Frame-Options = "SAMEORIGIN";
+  # } else {
+  #   set resp.http.X-Frame-Options = "DENY";
+  # }
+
+  set resp.http.X-Content-Type-Options = "nosniff";
+  set resp.http.X-XSS-Protection = "1; mode=block";
+  set resp.http.Strict-Transport-Security = "max-age=2629800";
+
+  if (req.url ~ "^/(en/|fr/)?(search/|recherche/)site/") {
+    set resp.http.X-Robots-Tag = "noindex, nofollow";
+  }
+
+  # Happens when we have all the pieces we need, and are about to send the
+  # response to the client.
+  #
+  # You can do accounting or modifying the final object here.
+  if (obj.hits > 0) {
+    set resp.http.X-Cache = "HIT";
+  } else {
+    set resp.http.X-Cache = "MISS";
+  }
+  # Handle errors
+  # if ( (resp.status >= 500 && resp.status <= 599)
+  #   || resp.status == 400
+  #   || resp.status == 401
+  #   || resp.status == 403
+  #   || resp.status == 404) {
+  #   return (synth(resp.status));
+  # }
+}
+
+sub vcl_synth {
+  # Remove identifying information
+  unset resp.http.Server;
+  unset resp.http.X-Powered-By;
+  unset resp.http.X-Varnish;
+  unset resp.http.Via;
+
+  # Add Content-Security-Policy
+  # set resp.http.Content-Security-Policy = "default-src 'self' *.example.ca; style-src 'self' 'unsafe-inline' *.example.ca; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.example.ca *.adobedtm.com use.fontawesome.com blob:; connect-src 'self' *.example.ca *.omtrdc.net *.demdex.net *.everesttech.net; img-src 'self' *.example.ca data:;";
+  # set resp.http.X-Content-Type-Options = "nosniff";
+  # set resp.http.X-Frame-Options = "DENY";
+  # set resp.http.X-XSS-Protection = "1; mode=block";
+
+  set resp.http.Strict-Transport-Security = "max-age=2629800";
+
+  # if (resp.status >= 500 && resp.status <= 599) {
+  #   set resp.http.Content-Type = "text/html; charset=utf-8";
+  #   synthetic(std.fileread("/data/configuration/varnish/errors/503.html"));
+  #   return (deliver);
+  # } elseif (resp.status == 400) { # 400 - Bad Request
+  #   set resp.http.Content-Type = "text/html; charset=utf-8";
+  #   synthetic(std.fileread("/data/configuration/varnish/errors/400.html"));
+  #   return (deliver);
+  # } elseif (resp.status == 401) { # 401 - Unauthorized
+  #   set resp.http.Content-Type = "text/html; charset=utf-8";
+  #   synthetic(std.fileread("/data/configuration/varnish/errors/401.html"));
+  #   return (deliver);
+  # } elseif (resp.status == 403) { # 403 - Forbidden
+  #   set resp.http.Content-Type = "text/html; charset=utf-8";
+  #   synthetic(std.fileread("/data/configuration/varnish/errors/403.html"));
+  #   return (deliver);
+  # } elseif (resp.status == 404) { # 404 - Not Found
+  #   set resp.http.Content-Type = "text/html; charset=utf-8";
+  #   synthetic(std.fileread("/data/configuration/varnish/errors/404.html"));
+  #   return (deliver);
+  # } else
+  if (resp.status == 700) { # Respond to healthcheck
+    set resp.status = 200;
+    set resp.http.Content-Type = "text/plain";
+    synthetic ( {"OK"} );
+    return (deliver);
+  } elseif (resp.status == 701) { # Respond to splash
+    set resp.status = 200;
+    set resp.http.Content-Type = "text/html";
+    synthetic(std.fileread("/etc/varnish/splash.html"));
+    return (deliver);
+  }
+}
+
+##
+# ERROR HANDLING
+##
+# sub vcl_backend_error {
+#   set beresp.http.Content-Type = "text/html; charset=utf-8";
+#   synthetic(std.fileread("/data/configuration/varnish/errors/503.html"));
+#   return (deliver);
+# }

--- a/images/appsvc/conf/nginx.conf
+++ b/images/appsvc/conf/nginx.conf
@@ -1,0 +1,165 @@
+# https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/
+error_log /proc/self/fd/2;
+pid /var/run/nginx.pid;
+user nginx;
+worker_processes auto;
+worker_rlimit_nofile 100000;
+
+events {
+  multi_accept on;
+  use epoll;
+  worker_connections 8192;
+}
+
+http {
+  access_log /proc/self/fd/1;
+  client_max_body_size 20m;
+  default_type application/octet-stream;
+  fastcgi_buffers 8 16k;
+  fastcgi_buffer_size 32k;
+  gzip on;
+  gzip_buffers 16 8k;
+  gzip_comp_level 4;
+  gzip_disable msie6;
+  gzip_proxied off;
+  gzip_types application/json;
+  gzip_vary on;
+  include /etc/nginx/mime.types;
+  index index.html index.htm;
+  keepalive_timeout 120;
+  proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=one:8m max_size=3000m inactive=600m;
+  proxy_temp_path /var/tmp;
+  sendfile on;
+  server_tokens off;
+  tcp_nopush on;
+  types_hash_max_size 2048;
+
+  server {
+      # IPv4
+      listen 8080;
+
+      # IPv6
+      listen [::]:8080;
+
+      # Filesystem root of the site and index with fallback.
+      root /var/www/html;
+      index index.php index.html index.htm;
+
+      # Make site accessible.
+      server_name drupal.dev;
+
+      location = /favicon.ico {
+          log_not_found off;
+          access_log off;
+      }
+
+      location = /robots.txt {
+          allow all;
+          log_not_found off;
+          access_log off;
+      }
+
+      location ~ \..*/.*\.php$ {
+          return 403;
+      }
+
+      location ~ ^/sites/.*/private/ {
+          return 403;
+      }
+
+      # Block access to scripts in site files directory
+      location ~ ^/sites/[^/]+/files/.*\.php$ {
+          deny all;
+      }
+
+      # Allow "Well-Known URIs" as per RFC 5785
+      location ~* ^/.well-known/ {
+          allow all;
+      }
+
+      # Block access to "hidden" files and directories whose names begin with a
+      # period. This includes directories used by version control systems such
+      # as Subversion or Git to store control files.
+      location ~ (^|/)\. {
+          return 403;
+      }
+
+      location / {
+          # First attempt to serve request as file, then
+          # as directory, then fall back to displaying a 404.
+          try_files $uri $uri/ /index.html /index.php?$query_string;
+      }
+
+      location @rewrite {
+          # For Drupal >= 7
+          rewrite ^ /index.php;
+      }
+
+      # Don't allow direct access to PHP files in the vendor directory.
+      location ~ /vendor/.*\.php$ {
+          deny all;
+          return 404;
+      }
+
+      # Protect files and directories from prying eyes.
+      location ~* \.(engine|ht|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|/(\.(?!well-known).*)|composer\.(json|lock)|web\.config$|/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+          deny all;
+          return 404;
+      }
+
+      # In Drupal 8, we must also match new paths where the '.php' appears in
+      # the middle, such as update.php/selection. The rule we use is strict,
+      # and only allows this pattern with the update.php front controller.
+      # This allows legacy path aliases in the form of
+      # blog/index.php/legacy-path to continue to route to Drupal nodes. If
+      # you do not have any paths like that, then you might prefer to use a
+      # laxer rule, such as:
+      #   location ~ \.php(/|$) {
+      # The laxer rule will continue to work if Drupal uses this new URL
+      # pattern with front controllers other than update.php in a future
+      # release.
+      location ~ '\.php$|^/update.php' {
+        proxy_intercept_errors on;
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        # Ensure the php file exists. Mitigates CVE-2019-11043
+        try_files $fastcgi_script_name =404;
+        # NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi_params;
+        # Block httpoxy attacks. See https://httpoxy.org/.
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param QUERY_STRING $query_string;
+        fastcgi_intercept_errors on;
+        # For the appsvc image please use
+        # fastcgi_pass 127.0.0.1:9000
+        fastcgi_pass web:9000;
+      }
+
+      location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+          try_files $uri @rewrite;
+          expires max;
+          log_not_found off;
+      }
+
+      # Fighting with Styles
+      location ~ ^/sites/.*/files/styles/ {
+          # For Drupal >= 7
+          try_files $uri @rewrite;
+      }
+
+      # Handle private files through Drupal. Private file's path can come
+      # with a language prefix.
+      location ~ ^(/[a-z\-]+)?/system/files/ {
+          # For Drupal >= 7
+          try_files $uri /index.php?$query_string;
+      }
+
+      # Enforce clean URLs
+      # Removes index.php from urls like www.example.com/index.php/my-page --> www.example.com/my-page
+      # Could be done with 301 for permanent or other redirect codes.
+      if ($request_uri ~* "^(.*/)index\.php/(.*)") {
+          return 307 $1$2;
+      }
+  }
+}

--- a/images/appsvc/conf/splash.html
+++ b/images/appsvc/conf/splash.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+  <!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr" xmlns="http://www.w3.org/1999/xhtml"><![endif]-->
+  <!--[if gt IE 8]><!-->
+  <html dir="ltr" xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <!--<![endif]-->
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+    <title>Canada.ca</title>
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <meta name="description"
+      content="The Government of Canada website is a single point of access to all programs, services, departments, ministries and organizations of the Government of Canada.">
+    <meta name="description" lang="fr"
+      content="Le site Web du gouvernement du Canada fournit un point d'accès complet à tous les programmes, services, départements, ministères et organismes du gouvernement du Canada.">
+    <meta name="dcterms.creator"
+      content="Government of Canada">
+    <meta name="dcterms.creator" lang="fr"
+      content="Gouvernement du Canada">
+    <meta name="dcterms.title" content="Canada.ca">
+    <meta name="dcterms.title" lang="fr" content="Canada.ca">
+    <meta name="dcterms.issued" title="W3CDTF" content="2021-11-01">
+    <meta name="dcterms.modified" title="W3CDTF" content="2021-11-01">
+    <meta name="dcterms.subject" title="gccore"
+      content="GV Government and Politics">
+    <meta name="dcterms.subject" lang="fr" title="gccore"
+      content="GV Gouvernement et vie politique">
+    <meta name="dcterms.language" title="ISO639-2" content="eng">
+    <meta name="dcterms.language" lang="fr" title="ISO639-2" content="fra">
+    <meta name="dcterms.spatial" content="Canada" />
+    <meta name="dcterms.spatial" lang="fr" content="Canada" />
+    <meta name="dcterms.type" content="navigation page" />
+    <meta name="dcterms.type" lang="fr" content="page de navigation" />
+    <meta name="robots" content="noindex, follow" />
+    <!--[if gte IE 9 | !IE ]><!-->
+    <link rel="apple-touch-icon" sizes="57x57 72x72 114x114 144x144 150x150" class="wb-favicon"
+      href="/libraries/theme-gcweb/assets/favicon-mobile.png">
+    <link href="/libraries/theme-gcweb/assets/favicon.ico" rel="icon" type="image/x-icon"
+      class="wb-init wb-favicon-inited">
+    <link rel="stylesheet" href="/libraries/theme-gcweb/css/wet-boew.css">
+    <script src="/core/assets/vendor/jquery/jquery.min.js?v=3.4.1"></script>
+    <script src="/libraries/wet-boew/js/wet-boew.min.js"></script>
+    <script src="/libraries/theme-gcweb/js/theme.min.js"></script>
+    <!--<![endif]-->
+    <link rel="stylesheet" href="/libraries/theme-gcweb/css/theme.css">
+    <link rel="stylesheet" href="/libraries/theme-gcweb/css/messages.css">
+    <!--[if lt IE 9]>
+    <link href="/libraries/theme-gcweb/assets/favicon.ico" rel="shortcut icon" />
+    <link rel="stylesheet" href="/libraries/theme-gcweb/css/messages-ie.min.css">
+    <link rel="stylesheet" href="/libraries/theme-gcweb/css/ie8-wet-boew.min.css" />
+    <script src="/libraries/theme-gcweb/js/ie8-wet-boew.min.js"></script>
+    <![endif]-->
+  </head>
+  <body class="splash">
+    <main>
+      <div id="bg"><img id="splash-image" src="/libraries/theme-gcweb/assets/sp-bg-2.jpg" alt=""></div>
+      <main property="mainContentOfPage" typeof="WebPageElement">
+        <div class="sp-hb">
+          <div class="sp-bx col-xs-12">
+            <h1 property="name" class="wb-inv">Canada.ca</h1>
+            <div class="row">
+              <div class="col-xs-11 col-md-8">
+                <img src="/libraries/theme-gcweb/assets/sig-spl.svg" alt="Government of Canada / Gouvernement du Canada">
+              </div>
+            </div>
+            <div class="row">
+              <section class="col-xs-6 text-right">
+                <h2>Canada.ca</h2>
+                <p><a href="/en" class="btn btn-primary">English</a></p>
+              </section>
+              <section class="col-xs-6" lang="fr">
+                <h2>Canada.ca</h2>
+                <p><a href="/fr" class="btn btn-primary">Français</a></p>
+              </section>
+            </div>
+          </div>
+          <div class="sp-bx-bt col-xs-12">
+            <div class="row">
+              <div class="col-xs-7 col-md-8">
+                <a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">Terms &amp; conditions</a> <span
+                  class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html"
+                  class="sp-lk" lang="fr">Avis</a>
+              </div>
+
+              <div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
+                <img src="/libraries/theme-gcweb/assets/wmms-spl.svg"
+                  alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada">
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+  </body>
+</html>

--- a/images/appsvc/conf/supervisord.ini
+++ b/images/appsvc/conf/supervisord.ini
@@ -29,7 +29,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:varnish]
-command=varnish
+command=varnishd -f /etc/varnish/default.vcl
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Worked with @smulvih2 on this. 

These changes set up the appsvc image to run the varnishd command with supervisord and change the port for NGINX to 8080. I also changed the default.vcl config to point to the localhost on port 8080 for NGINX.

The custom configuration files are moved to images/appsvc/conf/ since these are unique to the monolith style container.