### PR TITLE
Allow varnish to be toggle-able for appsvc

### DIFF
--- a/images/appsvc/Dockerfile
+++ b/images/appsvc/Dockerfile
@@ -2,6 +2,8 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE as src
 
+ARG VARNISH=false
+
 # Configure supervisor
 RUN apk add --no-cache supervisor
 RUN mkdir -p /etc/supervisor.d/
@@ -19,11 +21,13 @@ COPY tasks/ /etc/periodic/
 RUN chmod -R +x /etc/periodic/
 
 # Configure varnish
-RUN apk add --no-cache varnish
 RUN mkdir -p /etc/varnish
-
 COPY conf/default.vcl /etc/varnish/default.vcl
 COPY conf/splash.html /etc/varnish/splash.html
+
+RUN if [ "$VARNISH" = "true" ]; then \
+    apk add --no-cache varnish; \
+fi
 
 # ------------------------
 # SSH Server support


### PR DESCRIPTION
I have a project using the 9.5.x branch and it has been deployed to Prod. The new builds are pulling the Varnish changes that were recently pushed to 9.5.x, which is breaking the site. Can we add an env variable to enable Varnish, so projects that don't want to use it can have this disabled? This PR is my idea, will test this now and report back.