### PR TITLE
Adding optional local redis install for appsvc

### DIFF
--- a/images/appsvc/Dockerfile
+++ b/images/appsvc/Dockerfile
@@ -29,6 +29,10 @@ RUN if [ "$VARNISH" = "true" ]; then \
     apk add --no-cache varnish; \
 fi
 
+RUN if [ "$REDIS" = "true" ]; then \
+    apk --update add redis; \
+fi
+
 # ------------------------
 # SSH Server support
 # Alpine Reference: https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#enable-ssh

--- a/images/appsvc/conf/supervisord.ini
+++ b/images/appsvc/conf/supervisord.ini
@@ -34,3 +34,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:redis]
+command=/usr/bin/redis-server
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/redis/stdout.log
+stderr_logfile=/var/log/redis/stderr.log


### PR DESCRIPTION
Installs Redis locally for Drupal running on appsvc image. It's an optional installation with the REDIS environment parameter since there's other people using services/other docker containers for Redis. Using `--build-arg REDIS=true` should allow docker to install Redis.