### PR TITLE
Adding optional varnish backend host domain variable

### DIFF
--- a/images/appsvc/conf/default.vcl
+++ b/images/appsvc/conf/default.vcl
@@ -61,8 +61,13 @@ sub vcl_recv {
 }
 
 sub vcl_backend_fetch {
-  # NEW
-  set bereq.http.Host = "nginx";
+  # Check for host domain env variable, otherwise stick with normal nginx host
+  if (std.getenv("VARNISH_BACKEND_HOST_DOMAIN")) {
+    set bereq.http.Host = std.getenv("VARNISH_BACKEND_HOST_DOMAIN");
+  }
+  else {
+    set bereq.http.Host = "nginx";
+  }
 
   # Don't add 127.0.0.1 to X-Forwarded-For
   set bereq.http.X-Forwarded-For = regsub(bereq.http.X-Forwarded-For, "(, )?127\.0\.0\.1$", "");

--- a/images/appsvc/conf/default.vcl
+++ b/images/appsvc/conf/default.vcl
@@ -74,7 +74,7 @@ sub vcl_backend_fetch {
 }
 
 sub vcl_backend_response {
-  if (beresp.http.Location && beresp.http.Location !~ "^https://api.twitter.com/") {
+  if (beresp.http.Location && beresp.http.Location !~ "^https://api.twitter.com/" && beresp.http.Location !~ "^https://login.microsoftonline.com/") {
     set beresp.http.Location = regsub(
       beresp.http.Location,
       "^https?://[^/]+/",


### PR DESCRIPTION
I ran into a couple of issues while using the appsvc image with varnish. Some modules will utilize the backend host domain set by Varnish and redirect to the backend domain instead of your site's domain. My fix for this is to set an environment variable to the domain you would like the backend host to be.

For example, your DrupalWxT site's domain is https://example.ca and a module did a redirect based on the domain assigned by varnish, it would redirect to https://nginx/ since the `bereq.http.Host` is set to nginx in vcl_backend_fetch. If I assign `VARNISH_BACKEND_HOST_DOMAIN` to "example.ca" then the module will use the correct domain when it redirects with http Host.

