### PR TITLE
Add redis config to set memory management defaults to better values

### DIFF
--- a/images/appsvc/Dockerfile
+++ b/images/appsvc/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache nginx
 RUN mkdir -p /etc/nginx
 
 COPY conf/nginx.conf /etc/nginx/nginx.conf
+COPY conf/redis.conf /etc/redis.conf
 
 # Configure cron
 COPY tasks/ /etc/periodic/

--- a/images/appsvc/conf/redis.conf
+++ b/images/appsvc/conf/redis.conf
@@ -1,0 +1,60 @@
+################################## NETWORK #####################################
+
+bind 127.0.0.1 -::1
+protected-mode yes
+port 6379
+tcp-backlog 511
+unixsocket /run/redis/redis.sock
+unixsocketperm 770
+timeout 0
+tcp-keepalive 300
+
+################################# GENERAL #####################################
+
+databases 16
+always-show-logo no
+set-proc-title yes
+locale-collate ""
+
+################################# REPLICATION #################################
+
+replica-serve-stale-data yes
+replica-read-only yes
+repl-diskless-sync yes
+repl-diskless-sync-delay 5
+repl-diskless-sync-max-replicas 0
+repl-diskless-load disabled
+
+
+############################## MEMORY MANAGEMENT ################################
+
+maxmemory 500mb
+maxmemory-policy allkeys-lru
+
+################################ LATENCY MONITOR ##############################
+
+latency-monitor-threshold 0
+
+################################ EVENT NOTIFICATION ##############################
+
+notify-keyspace-events ""
+
+################################### ADVANCED CONFIG ###############################
+
+hash-max-listpack-entries 512
+hash-max-listpack-value 64
+list-max-listpack-size -2
+list-compress-depth 0
+set-max-intset-entries 512
+set-max-listpack-entries 128
+set-max-listpack-value 64
+zset-max-listpack-entries 128
+zset-max-listpack-value 64
+hll-sparse-max-bytes 3000
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+
+activerehashing yes
+dynamic-hz yes
+aof-rewrite-incremental-fsync yes
+rdb-save-incremental-fsync yes

--- a/images/appsvc/conf/supervisord.ini
+++ b/images/appsvc/conf/supervisord.ini
@@ -36,7 +36,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:redis]
-command=/usr/bin/redis-server
+command=/usr/bin/redis-server /etc/redis.conf
 autostart=true
 autorestart=true
 stdout_logfile=/var/log/redis/stdout.log


### PR DESCRIPTION
I have the appsvc image deployed to Azure app service for a project and it's works great! We are however seeing an issue with memory usage. Memory slowly keeps increasing until it has used all resources. I was able to both scale up and scale out, and the issue persists, consistently growing memory usage. I tracked the issue back to Redis, which is now included in the appsvc image, instead of having to be a managed service.

Since there is no config provided for Redis, it uses it's default. In particular, it has "maxmemory-policy" set to "noeviction", and "maxmemory" set to "0". This means redis will not evict expired cache, and the cache can grow infinitely large. Once I manually set these with other values via redic-cli, the memory problem is resolved.

```
$ redis-cli
$ CONFIG SET maxmemory 500mb
$ CONFIG SET maxmemory-policy allkeys-lru
```

I propose we include the default Redis configuration with these changes.