### PR TITLE
Set Varnish http_resp_hdr_len to 64k to prevent 503 error

### DIFF
--- a/images/appsvc/conf/supervisord.ini
+++ b/images/appsvc/conf/supervisord.ini
@@ -29,7 +29,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:varnish]
-command=varnishd -f /etc/varnish/default.vcl
+command=varnishd -f /etc/varnish/default.vcl -p http_resp_hdr_len=64k
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
On a project using the appsvc image in Prod, there was an issue reported where the second page of search results was giving a 503 error:

```
Error 503 Backend fetch failed
Backend fetch failed

Guru Meditation:
XID: 8881713

Varnish cache server
```
Using `varnishlog` to look at the output from the 503, I see this:

`BogoHeader     Header too long: Cache-Tags: config:b`

This indicates that one of the headers, specifically Cache-Tags, exceeded the allowed length. Varnish is very strict about header sizes, and if a header is too long, it can lead to issues. So our search page, which lists a bunch of nodes, has too many cache tags and therefore kills Varnish.

If I run this in my environment, `varnishadm param.show http_resp_hdr_len`, I can see the default of 8kb is being used. Increasing this to a larger limit, `varnishadm param.set http_resp_hdr_len 64k`, resolves the issue.

This PR sets the `http_resp_hdr_len` value to 64k in the supervisord.ini file. I have tested this and it resolved the 503 error.