### PR TITLE
Performance fixes, prevent errors that happen when memory buffer is full.

### DIFF
--- a/images/appsvc/conf/supervisord.ini
+++ b/images/appsvc/conf/supervisord.ini
@@ -29,7 +29,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:varnish]
-command=varnishd -f /etc/varnish/default.vcl -p http_resp_hdr_len=64k
+command=varnishd -f /etc/varnish/default.vcl -p thread_pool_min=50 -p thread_pool_max=200 -p thread_pool_timeout=120 -p http_req_hdr_len=32M -p http_resp_size=32M -p http_resp_hdr_len=32M -p workspace_backend=2M -p workspace_client=2M -p workspace_session=1M -s malloc,4096M
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Update supervisord.ini

Once merged, this change should also be cherry-picked for 10.4.x
