### PR TITLE
Respect Azure App Service forwarding headers in Nginx

### DIFF
--- a/images/appsvc/conf/nginx.conf
+++ b/images/appsvc/conf/nginx.conf
@@ -34,6 +34,25 @@ http {
   tcp_nopush on;
   types_hash_max_size 2048;
 
+  # Respect Azure/App Service forwarding headers
+  map $http_x_forwarded_proto $fastcgi_https {
+    default off;
+    https   on;
+  }
+
+  map $http_x_forwarded_host $host_to_use {
+    default $http_x_forwarded_host;
+    ""      $host;
+  }
+
+  map $http_x_forwarded_port $server_port_to_use {
+    default $http_x_forwarded_port;
+    ""      $server_port;
+  }
+
+  # Preserve client IP for logs
+  real_ip_header X-Forwarded-For;
+
   server {
       # IPv4
       listen 8080;
@@ -130,6 +149,20 @@ http {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_param QUERY_STRING $query_string;
+
+        # Normalize protocol and host headers for upstream (App Service)
+        fastcgi_param HTTPS $fastcgi_https;
+        fastcgi_param HTTP_HOST $host_to_use;
+        fastcgi_param SERVER_NAME $host_to_use;
+        fastcgi_param SERVER_PORT $server_port_to_use;
+        fastcgi_param REMOTE_ADDR $http_x_forwardrd_for;
+
+        # Preserve real client IP and proxy context
+        fastcgi_param REMOTE_ADDR $http_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_HOST  $http_host;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_X_FORWARDED_PORT  $server_port;
+
         fastcgi_intercept_errors on;
         # For the appsvc image please use
         fastcgi_pass 127.0.0.1:9000;


### PR DESCRIPTION
When running the docker-scaffold appsvc container in Azure App Service, requests proxied through Azure’s front-end load balancers lose the original scheme and host headers, causing Drupal to detect the site as `http://nginx/` instead of the correct domain. This results in incorrect redirects, broken language negotiation, and issues when enabling domain-based detection.

This update adds explicit header mapping and forwarding logic to Nginx to correctly respect Azure’s `X-Forwarded-*` headers.

**Purpose / Rationale:**

- Fixes incorrect redirects (http://nginx) in Azure App Service.
- Ensures Drupal correctly detects HTTPS and the true host name.
- Preserves client IP address in PHP logs and Drupal sessions.
- Enables proper behavior for multilingual/domain-based language negotiation.

**Testing:**

- Deploy to Azure App Service using appsvc image.
- Visit site over HTTPS and confirm:
- Drupal base URL and redirects resolve to the correct custom domain.
- $base_url or $_SERVER['HTTPS'] properly reflect `on`.
- `X-Forwarded-*` headers appear correctly in phpinfo().
- Flush cache through the Drupal UI (should not get a redirect error)
- Visit the cron page to see the cron URL starts with your domain instead of `https://nginx`

I have this patch running at PSPC for a Drupal 10 WxT multi-site with domain-based language negotiation, as well as another project running plain Drupal (sans-WxT). In both cases this change fixes the issues.